### PR TITLE
Develop v0.0.0.9002

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [v0.0.0.9001] - yyyy-mm-dd
+## [v0.0.0.9002] - yyyy-mm-dd
 
 ### Added
   - NA

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Hurricanes
 Type: Package
 Title: Hurricanes
-Version: 0.0.0.9001
+Version: 0.0.0.9002
 Authors@R: person("Tim", "Trice", email = "tim.trice@gmail.com",
                   role = c("aut", "cre"))
 Depends:

--- a/R/get_storms.R
+++ b/R/get_storms.R
@@ -98,8 +98,8 @@ year <- .extract_year_archive_link(link)
 #' @return Dataframe of storms.
 #' @importFrom data.table rbindlist
 #' @examples 
-#' # Default. Get all storms, both basins, for current year.
-#' storms <- get_storms(year = lubridate::year(Sys.Date()), basin = c("AL", "EP"))
+#' # Default. Get all storms, both basins, for last year.
+#' storms <- get_storms(year = 2016, basin = c("AL", "EP"))
 #' 
 #' # Get storms for two different years
 #' storms.2010 <- get_storms(c(2010, 2015))

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Travis-CI Build Status](https://travis-ci.org/timtrice/Hurricanes.svg?branch=master)](https://travis-ci.org/timtrice/Hurricanes)
+[![Travis-CI Build Status](https://travis-ci.org/timtrice/Hurricanes.svg?branch=develop-v0.0.0.9002)](https://travis-ci.org/timtrice/Hurricanes)
 
 # Hurricanes
 

--- a/man/get_storms.Rd
+++ b/man/get_storms.Rd
@@ -32,8 +32,8 @@ By default returns all storms for the current year. If no storms
 have developed will return an empty dataframe.
 }
 \examples{
-# Default. Get all storms, both basins, for current year.
-storms <- get_storms(year = lubridate::year(Sys.Date()), basin = c("AL", "EP"))
+# Default. Get all storms, both basins, for last year.
+storms <- get_storms(year = 2016, basin = c("AL", "EP"))
 
 # Get storms for two different years
 storms.2010 <- get_storms(c(2010, 2015))


### PR DESCRIPTION
Originally, `get_storms` example code used the current year as a default. When this commit was done there were no storms, thus the example code generated errors. This commit resolves that. 

Version bump as well to v0.0.0.9002. After this pull, versioning will use [Semantic Versioning](http://semver.org/) starting at 0.1.0. Milestones for those versions will be tracked in Issues. 